### PR TITLE
Start of product CRUD & admin user strategy

### DIFF
--- a/front-end/src/components/Aside/Aside.js
+++ b/front-end/src/components/Aside/Aside.js
@@ -96,10 +96,26 @@ function Aside() {
                 </li> 
 
                 <li>
-                   <a href="/register">
+                   <a href="/createProduct">
                          <i className="fa fa-power-off fa-2x"></i>
                         <span className="nav-text">
-                            Employee Login
+                            Create Product
+                        </span>
+                    </a>
+                </li> 
+                <li>
+                   <a href="/editProduct">
+                         <i className="fa fa-power-off fa-2x"></i>
+                        <span className="nav-text">
+                            Edit Product
+                        </span>
+                    </a>
+                </li> 
+                <li>
+                   <a href="/deleteProduct">
+                         <i className="fa fa-power-off fa-2x"></i>
+                        <span className="nav-text">
+                            Delete Product
                         </span>
                     </a>
                 </li> 

--- a/front-end/src/components/Pages/Pages.js
+++ b/front-end/src/components/Pages/Pages.js
@@ -20,6 +20,9 @@ function MainContent(){
     <Route path = "/documentation" element={<Documentation/>}/>
     <Route path = "/404" element={<PageNotFound/>}/>
     <Route path = "/newPage" element={<NewPage/>}/>
+    <Route path = "/createProduct" element={<CreateProduct/>}/>
+    <Route path = "/editProduct" element={<EditProduct/>}/>
+    <Route path = "/deleteProduct" element={<DeleteProduct/>}/>
     </Routes>  
 
     );
@@ -300,6 +303,25 @@ function Register(){
  
       <h1>This is the new page page</h1>
 
+    );
+  }
+
+  // create product page ...............
+  function CreateProduct(props){
+    return(
+      <h1>This is our admin only create product page</h1>
+    );
+  }
+  // edit product page ...............
+  function EditProduct(props){
+    return(
+      <h1>This is our admin only edit product page</h1>
+    );
+  }
+  // create product page ...............
+  function DeleteProduct(props){
+    return(
+      <h1>This is our admin only delete product page</h1>
     );
   }
 export default MainContent


### PR DESCRIPTION
We will be adding an "isAdmin" Boolean to our user schema that will be set to false upon registration and can only be manually changed in the database. (pretend the customer has to call IT to change a user to admin status). This way we utilize only one login page and can also give or take away admin status to any user. Users will need to have { isAdmin: true } in order to view our product crud pages once we get that set up.

-----Tonight's updates-----
Pages.js - I added functions and routes for CreateProduct, EditProduct and DeleteProduct
Aside.js - I added the list item links to the CreateProduct, EditProduct and DeleteProduct pages